### PR TITLE
Reduce cognitive complexity get review metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   # Include common Ruby source files.
-  TargetRubyVersion: 2.2.7
+  TargetRubyVersion: 2.6.*
   Exclude:
     - 'bin/**/*'
     - 'config/**/*'

--- a/app/helpers/review_mapping_helper.rb
+++ b/app/helpers/review_mapping_helper.rb
@@ -133,7 +133,7 @@ module ReviewMappingHelper
   def get_review_metrics(round, team_id)
     %i[max min avg].each {|metric| instance_variable_set('@' + metric.to_s, '-----') }
     condition1 = @avg_and_ranges[team_id] && @avg_and_ranges[team_id][round]
-    condition2 = @avg_and_ranges[team_id][round] && %i[max min avg].all?
+    condition2 = condition1 && %i[max min avg].all?
     if condition1 && condition2 {|k| @avg_and_ranges[team_id][round].key? k }
       %i[max min avg].each do |metric|
         if @avg_and_ranges[team_id][round][metric].nil?

--- a/app/helpers/review_mapping_helper.rb
+++ b/app/helpers/review_mapping_helper.rb
@@ -140,7 +140,6 @@ module ReviewMappingHelper
   def get_review_metrics(round, team_id)
     %i[max min avg].each {|metric| instance_variable_set('@' + metric.to_s, '-----') }
     if @avg_and_ranges.dig(team_id, round) && %i[max min avg].all? {|k| @avg_and_ranges[team_id][round].key? k }
-
       %i[max min avg].each do |metric|
         metric_value = @avg_and_ranges[team_id][round][metric].nil? ? '-----' : @avg_and_ranges[team_id][round][metric].round(0).to_s + '%'
         instance_variable_set('@' + metric.to_s, metric_value)

--- a/app/helpers/review_mapping_helper.rb
+++ b/app/helpers/review_mapping_helper.rb
@@ -132,9 +132,7 @@ module ReviewMappingHelper
   # gets minimum, maximum and average value for all the reviews
   def get_review_metrics(round, team_id)
     %i[max min avg].each {|metric| instance_variable_set('@' + metric.to_s, '-----') }
-    condition1 = @avg_and_ranges[team_id] && @avg_and_ranges[team_id][round]
-    condition2 = condition1 && %i[max min avg].all?
-    if condition1 && condition2 {|k| @avg_and_ranges[team_id][round].key? k }
+    if @avg_and_ranges.dig(team_id, round) && %i[max min avg].all? {|k| @avg_and_ranges[team_id][round].key? k }
       %i[max min avg].each do |metric|
         if @avg_and_ranges[team_id][round][metric].nil?
             metric_value = '-----'


### PR DESCRIPTION
Reduce the cognitive complexity of get_review_metrics function by using dig method for instance variable